### PR TITLE
Make GitHub detect *.zf as Forth.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.zf linguist-language=Forth


### PR DESCRIPTION
 Hello,  

Please merge this, if you'd like GitHub to detect your `.zf` files as Forth.

Thank you!  