### PR TITLE
Fix linux readline memory leak

### DIFF
--- a/src/linux/main.c
+++ b/src/linux/main.c
@@ -285,6 +285,7 @@ int main(int argc, char **argv)
 
 		}
 
+		free(buf);
 	}
 #else
 	for(;;) {


### PR DESCRIPTION
### Purpose:

readline buf is malloced so it should be freed by hand once done.

### Example:

```sh
$ ./src/linux/zforth forth/core.zf
Welcome to zForth, 1035 bytes used
: hw ." Hello world" ;

hw
Hello world
hw
Hello world
hw
Hello world
hw
Hello world
hw
Hello world


=================================================================
==4910==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 32 byte(s) in 4 object(s) allocated from:
    #0 0x7f8cc2df9330 in __interceptor_malloc (/lib/x86_64-linux-gnu/libasan.so.5+0xe9330)
    #1 0x7f8cc297a4e8 in xmalloc (/lib/x86_64-linux-gnu/libreadline.so.7+0x3a4e8)

SUMMARY: AddressSanitizer: 32 byte(s) leaked in 4 allocation(s).
```