### PR TITLE
Prevent re-entrancy into interpreter via nested zf_eval

### DIFF
--- a/src/zforth/zforth.c
+++ b/src/zforth/zforth.c
@@ -88,6 +88,9 @@ static const char uservar_names[] =
 
 static zf_addr *uservar = (zf_addr *)dict;
 
+/* Execution state */
+static bool running = false;
+
 
 /* Prototypes */
 
@@ -884,14 +887,23 @@ zf_result zf_eval(const char *buf)
 	zf_result r = (zf_result)setjmp(jmpbuf);
 
 	if(r == ZF_OK) {
+		if (running)
+		{
+			return ZF_ABORT_BUSY;
+		}
+
+		running = true;
+
 		for(;;) {
 			handle_char(*buf);
 			if(*buf == '\0') {
+				running = false;
 				return ZF_OK;
 			}
 			buf ++;
 		}
 	} else {
+		running = false;
 		COMPILING = 0;
 		rsp = 0;
 		dsp = 0;
@@ -905,6 +917,12 @@ void *zf_dump(size_t *len)
 	if(len) *len = sizeof(dict);
 	return dict;
 }
+
+bool zf_running(void)
+{
+    return running;
+}
+
 
 /*
  * End

--- a/src/zforth/zforth.h
+++ b/src/zforth/zforth.h
@@ -1,6 +1,7 @@
 #ifndef zforth_h
 #define zforth_h
 
+#include <stdbool.h>
 #include "zfconf.h"
 
 /* Abort reasons */
@@ -16,7 +17,8 @@ typedef enum {
 	ZF_ABORT_NOT_A_WORD,
 	ZF_ABORT_COMPILE_ONLY_WORD,
 	ZF_ABORT_INVALID_SIZE,
-	ZF_ABORT_DIVISION_BY_ZERO
+	ZF_ABORT_DIVISION_BY_ZERO,
+	ZF_ABORT_BUSY
 } zf_result;
 
 typedef enum {
@@ -56,6 +58,8 @@ void zf_abort(zf_result reason);
 void zf_push(zf_cell v);
 zf_cell zf_pop(void);
 zf_cell zf_pick(zf_addr n);
+
+bool zf_running(void);
 
 /* Host provides these functions */
 


### PR DESCRIPTION
The aim of this PR is to prevent nested `zf_eval` calls, which could occur if C code invoked via a user system call via `zf_eval` also then tries to call `zf_eval`.  This could be potentially handled at a higher-level within the application, via a wrapper function which invokes `zf_eval`.

I'm not sure of whether this type of re-entrancy is intended to be supported by zForth.  It might be that this change is inappropriate and does not fit in with the zForth design, in which case please feel free to drop it.  I just wanted to propose it in case it was of value to others.