### PR TITLE
Add functions to access uservars from C

### DIFF
--- a/src/zforth/zforth.c
+++ b/src/zforth/zforth.c
@@ -76,12 +76,11 @@ static jmp_buf jmpbuf;
  * C they are stored in an array of zf_addr with friendly reference names
  * through some macros */
 
-#define HERE      uservar[0]    /* compilation pointer in dictionary */
-#define LATEST    uservar[1]    /* pointer to last compiled word */
-#define TRACE     uservar[2]    /* trace enable flag */
-#define COMPILING uservar[3]    /* compiling flag */
-#define POSTPONE  uservar[4]    /* flag to indicate next imm word should be compiled */
-#define USERVAR_COUNT 5
+#define HERE      uservar[ZF_USERVAR_HERE]      /* compilation pointer in dictionary */
+#define LATEST    uservar[ZF_USERVAR_LATEST]    /* pointer to last compiled word */
+#define TRACE     uservar[ZF_USERVAR_TRACE]     /* trace enable flag */
+#define COMPILING uservar[ZF_USERVAR_COMPILING] /* compiling flag */
+#define POSTPONE  uservar[ZF_USERVAR_POSTPONE]  /* flag to indicate next imm word should be compiled */
 
 static const char uservar_names[] =
 	_("h")   _("latest") _("trace")  _("compiling")  _("_postpone");
@@ -504,7 +503,7 @@ static void execute(zf_addr addr)
 
 static zf_addr peek(zf_addr addr, zf_cell *val, int len)
 {
-	if(addr < USERVAR_COUNT) {
+	if(addr < ZF_USERVAR_COUNT) {
 		*val = uservar[addr];
 		return 1;
 	} else {
@@ -572,7 +571,7 @@ static void do_prim(zf_prim op, const char *input)
 			d2 = zf_pop();
 			addr = zf_pop();
 			d1 = zf_pop();
-			if(addr < USERVAR_COUNT) {
+			if(addr < ZF_USERVAR_COUNT) {
 				uservar[addr] = d1;
 				break;
 			}
@@ -817,7 +816,7 @@ static void handle_char(char c)
 
 void zf_init(int enable_trace)
 {
-	HERE = USERVAR_COUNT * sizeof(zf_addr);
+	HERE = ZF_USERVAR_COUNT * sizeof(zf_addr);
 	TRACE = enable_trace;
 	LATEST = 0;
 	dsp = 0;
@@ -916,6 +915,35 @@ void *zf_dump(size_t *len)
 {
 	if(len) *len = sizeof(dict);
 	return dict;
+}
+
+zf_result zf_uservar_set(zf_uservar_id uv, zf_cell v)
+{
+	zf_result result = ZF_ABORT_INVALID_USERVAR;
+
+	if (uv < ZF_USERVAR_COUNT)
+	{
+		uservar[uv] = v;
+		result = ZF_OK;
+	}
+
+	return result;
+}
+
+zf_result zf_uservar_get(zf_uservar_id uv, zf_cell *v)
+{
+	zf_result result = ZF_ABORT_INVALID_USERVAR;
+
+	if (uv < ZF_USERVAR_COUNT)
+	{
+		if (v != NULL)
+		{
+			*v = uservar[uv];
+		}
+		result = ZF_OK;
+	}
+
+	return result;
 }
 
 bool zf_running(void)

--- a/src/zforth/zforth.c
+++ b/src/zforth/zforth.c
@@ -921,8 +921,7 @@ zf_result zf_uservar_set(zf_uservar_id uv, zf_cell v)
 {
 	zf_result result = ZF_ABORT_INVALID_USERVAR;
 
-	if (uv < ZF_USERVAR_COUNT)
-	{
+	if (uv < ZF_USERVAR_COUNT) {
 		uservar[uv] = v;
 		result = ZF_OK;
 	}
@@ -934,10 +933,8 @@ zf_result zf_uservar_get(zf_uservar_id uv, zf_cell *v)
 {
 	zf_result result = ZF_ABORT_INVALID_USERVAR;
 
-	if (uv < ZF_USERVAR_COUNT)
-	{
-		if (v != NULL)
-		{
+	if (uv < ZF_USERVAR_COUNT) {
+		if (v != NULL) {
 			*v = uservar[uv];
 		}
 		result = ZF_OK;

--- a/src/zforth/zforth.h
+++ b/src/zforth/zforth.h
@@ -18,6 +18,7 @@ typedef enum {
 	ZF_ABORT_COMPILE_ONLY_WORD,
 	ZF_ABORT_INVALID_SIZE,
 	ZF_ABORT_DIVISION_BY_ZERO,
+	ZF_ABORT_INVALID_USERVAR,
 	ZF_ABORT_BUSY,
 	ZF_ABORT_EXTERNAL
 } zf_result;
@@ -46,6 +47,16 @@ typedef enum {
 	ZF_SYSCALL_USER = 128
 } zf_syscall_id;
 
+typedef enum {
+    ZF_USERVAR_HERE = 0,
+    ZF_USERVAR_LATEST,
+    ZF_USERVAR_TRACE,
+    ZF_USERVAR_COMPILING,
+    ZF_USERVAR_POSTPONE,
+
+    ZF_USERVAR_COUNT
+} zf_uservar_id;
+
 
 /* ZForth API functions */
 
@@ -59,6 +70,9 @@ void zf_abort(zf_result reason);
 void zf_push(zf_cell v);
 zf_cell zf_pop(void);
 zf_cell zf_pick(zf_addr n);
+
+zf_result zf_uservar_set(zf_uservar_id uv, zf_cell v);
+zf_result zf_uservar_get(zf_uservar_id uv, zf_cell *v);
 
 bool zf_running(void);
 


### PR DESCRIPTION
This PR aims to make access to uservars from the C side more robust and transparent.  It does this by adding an extendable enumeration for uservars in the public header, plus a couple of accessor functions.  The existing defines remain where they are, but are defined in terms of the enumeration values in the header.  This permits the user to query and update the uservars directly from C, with bounds-checking, and without giving them direct access to the Forth environment.  If needed, additional enumerations can be added to the enum, though at this point, it will still require an update to the name strings in zforth.c to match.