### PR TITLE
added 'dump' memory, vectored execution, TICK word working in non COMPILING mode ...

### DIFF
--- a/forth/core.zf
+++ b/forth/core.zf
@@ -26,7 +26,8 @@
 
 
 ( some operators and shortcuts )
-
+: 1+ 1 + ;
+: 1- 1 - ;
 : over 1 pick ;
 : +!   dup @ rot + swap ! ;
 : inc  1 swap +! ;
@@ -50,12 +51,25 @@
 
 
 ( 'begin' gets the current address, a jump or conditional jump back is generated
-  by 'again', 'until' or 'times' )
+  by 'again', 'until' )
 
 : begin   here ; immediate
 : again   ' jmp , , ; immediate
 : until   ' jmp0 , , ; immediate
-: times ' 1 - , ' dup , ' =0 , postpone until ; immediate
+
+
+( '{ ... ... ... n x}' repeat n times definition - eg. : 5hello { ." hello " 5 x} ; )
+
+: { ( -- ) ' lit , 0 , ' >r , here ; immediate
+: x} ( -- ) ' r> , ' 1+ , ' dup , ' >r , ' = , postpone until ' r> , ' drop , ; immediate
+
+
+( vectored execution - execute XT eg. ' hello exe )
+
+: exe ( XT -- ) ' lit , here dup , ' >r , ' >r , ' exit , here swap ! ; immediate
+
+( execute XT n times  e.g. ' hello 3 times )
+: times ( XT n -- ) { >r dup >r exe r> r> dup x} drop drop ;
 
 
 ( 'if' prepares conditional jump, address will be filled in by 'else' or 'fi' )

--- a/forth/dict.zf
+++ b/forth/dict.zf
@@ -11,4 +11,18 @@
 : name dup @ 31 & swap next dup next rot tell @ ;
 : words latest @ begin name 32 emit dup 0 = until cr drop ;
 
+( 'dump' memory make hex dump len bytes from addr )
+: hex_t ' lit ,  here dup , s" 0123456789abcdef" allot swap ! ; immediate
+: *hex_t hex_t ;
+: .hex *hex_t + @ emit ;
+: >nib ( n -- low high ) dup 15 & swap -16 & 16 / ;
+: ffemit ( n -- ) >nib .hex .hex ;
+: ffffemit ( n -- ) >nib >nib >nib { .hex 4 x} ;
+: @LSB ( addr -- LSB ) 2 @@ 255 & ;
+: between? ( n low_lim high_lim -- bool ) 2 pick > rot rot > & ; 
+: 4hex ( a -- a_new ) { dup @LSB ffemit 32 emit 1+ 4 x} 124 emit ;
+: 4ascii ( a -- a_new ) { dup @LSB dup 31 127 between? if emit else drop 46 emit fi 1+ 4 x} 124 emit ;
+: .addr ( a -- ) ffffemit ."    " ;
+: 16line ( a -- a_new ) dup .addr dup { 4hex 4 x} drop { 4ascii 4 x} cr ;
+: dump ( addr len -- ) over + swap begin 16line over over < until drop drop ; 
 

--- a/src/zforth/zforth.c
+++ b/src/zforth/zforth.c
@@ -672,9 +672,19 @@ static void do_prim(zf_prim op, const char *input)
 			break;
 
 		case PRIM_TICK:
-			ip += dict_get_cell(ip, &d1);
-			trace("%s/", op_name(d1));
-			zf_push(d1);
+			if (COMPILING) {
+				ip += dict_get_cell(ip, &d1);
+				trace("%s/", op_name(d1));
+				zf_push(d1);
+			}
+			else {
+				if (input) {
+					if (find_word(input,&addr,&len)) zf_push(len);
+					else zf_abort(ZF_ABORT_INTERNAL_ERROR);
+				}
+				else input_state = ZF_INPUT_PASS_WORD;
+			}
+					
 			break;
 
 		case PRIM_COMMA:


### PR DESCRIPTION
    modified:   forth/core.zf
added vectored execution e.g. `' my_word exe`

'times' word changed using vectored execution: e.g. `' my_word 5 times`

added { x} as block version of 'times': e.g. `: my_word { word1 word2 word3 5 x}`

added helper words `1+` and `1-` to make immediate words definition shorter
instead of `' lit , 1 , ' + ,` you can write `' 1+ ,`

	modified:   forth/dict.zf
added 'dump' for memory hexdump ( addr len -- ) e.g. `200 30 dump` dump 30 bytes starting from addr 200

	modified:   src/zforth/zforth.c
modified 'TICK' word to make it work in non COMPILING mode