### PR TITLE
Fix linux zf_host_parse_num implementation

### DIFF
--- a/src/linux/main.c
+++ b/src/linux/main.c
@@ -180,6 +180,27 @@ void zf_host_trace(const char *fmt, va_list va)
 	fprintf(stderr, "\033[0m");
 }
 
+static int isItNumber(const char *buf) {
+    int res = 1;
+    int len = strlen(buf);
+    int i = 0;
+    unsigned char ishex = 0;
+    
+    if (buf[0] == '-') {
+        i = 1;
+        
+    }
+    for(; i < len; i++) {
+        if (ishex && (buf[i] >= 'a' && buf[i] <= 'f')) {
+            continue;
+        }
+        if((!(buf[i] >= '0' && buf[i] <= '9')) && (buf[i] != '.')) {
+            res = 0;
+            break;
+        }
+    }
+    return res;
+}
 
 /*
  * Parse number
@@ -187,12 +208,16 @@ void zf_host_trace(const char *fmt, va_list va)
 
 zf_cell zf_host_parse_num(const char *buf)
 {
-	zf_cell v;
-	int r = sscanf(buf, "%f", &v);
-	if(r == 0) {
-		zf_abort(ZF_ABORT_NOT_A_WORD);
-	}
-	return v;
+    zf_cell v;
+    int r;
+
+    if( (r = isItNumber(buf))) {
+        r = sscanf(buf, "%f", &v);
+    }
+    if(r == 0) {
+        zf_abort(ZF_ABORT_NOT_A_WORD);
+    }
+    return v;
 }
 
 


### PR DESCRIPTION
In the current zf_host_parse_num implementation  have an issue if you want to use word which start with digit.
For example if you try to write on the console 2dup it isn't interpreted as word 2dup - it is interpreted as value 2 and it is added to dstack:
    2dup
    .
    2
With this patch naow result is as expected (2dup word isn't defined in dictionary):
    2dup
    stdin:1: not a word

 