### PR TITLE
new primitives - logical OR, XOR, bit rotations, speed up 3x by conditional trace() calls

### DIFF
--- a/src/linux/Makefile
+++ b/src/linux/Makefile
@@ -9,7 +9,7 @@ CC	:= $(CROSS)gcc
 
 VPATH   := ../zforth
 CFLAGS	+= -I. -I../zforth
-CFLAGS  += -Os -g -std=c89 -ansi -pedantic -MMD
+CFLAGS  += -Os -g -std=c99 -pedantic -MMD
 CFLAGS  += -fsanitize=address -Wall -Wextra -Werror -Wno-unused-parameter -Wno-clobbered -Wno-unused-result
 LDFLAGS	+= -fsanitize=address -g 
 


### PR DESCRIPTION
added or ` | `, xor ` ^ `, bitshift left and right ` << ` and ` >> `
changed `trace(fmt, ... )` calls to `if(TRACE) trace(fmt, ...)`
this brings interpreter speed gain up to 3x 
