### PR TITLE
Move rsp and dsp from static to uservar

### DIFF
--- a/src/zforth/zforth.h
+++ b/src/zforth/zforth.h
@@ -49,6 +49,8 @@ typedef enum {
     ZF_USERVAR_TRACE,
     ZF_USERVAR_COMPILING,
     ZF_USERVAR_POSTPONE,
+    ZF_USERVAR_DSP,
+    ZF_USERVAR_RSP,
 
     ZF_USERVAR_COUNT
 } zf_uservar_id;


### PR DESCRIPTION
This allows forth code to inspect (and modify!) the data and return stack pointers. This change slightly increases or decreases the resulting binary, depending on the architecture.