### PR TITLE
Fix compiling with integer cells

### DIFF
--- a/src/atmega8/zfconf.h
+++ b/src/atmega8/zfconf.h
@@ -38,6 +38,7 @@
 
 typedef int32_t zf_cell;
 #define ZF_CELL_FMT "%ld"
+#define ZF_SCAN_FMT "%ld"
 
 
 /* The type to use for pointers and adresses. 'unsigned int' is usually a good

--- a/src/linux/main.c
+++ b/src/linux/main.c
@@ -190,7 +190,7 @@ zf_cell zf_host_parse_num(const char *buf)
 {
 	zf_cell v;
 	int n = 0;
-	int r = sscanf(buf, "%f%n", &v, &n);
+	int r = sscanf(buf, ZF_SCAN_FMT"%n", &v, &n);
 	if(r != 1 || buf[n] != '\0') {
 		zf_abort(ZF_ABORT_NOT_A_WORD);
 	}

--- a/src/linux/zfconf.h
+++ b/src/linux/zfconf.h
@@ -38,6 +38,7 @@
 
 typedef float zf_cell;
 #define ZF_CELL_FMT "%.14g"
+#define ZF_SCAN_FMT "%f"
 
 
 /* The type to use for pointers and adresses. 'unsigned int' is usually a good


### PR DESCRIPTION
In case zfconf.h is modified so that zf_cell is an integer type, the sscanf() call in zf_host_parse_num() will no longer compile.

This is arguably a host-specific detail, but this commit proposes a solution wherein the scanf format specifier is also included in the zfconf.h definitions.