### PR TITLE
Fix the 'loop' construct end condition to match 'standard' Forth

### DIFF
--- a/forth/core.zf
+++ b/forth/core.zf
@@ -86,7 +86,7 @@
 : i ' lit , 0 , ' pickr , ; immediate
 : j ' lit , 2 , ' pickr , ; immediate
 : do ' swap , ' >r , ' >r , here ; immediate
-: loop+ ' r> , ' + , ' dup , ' >r , ' lit , 1 , ' pickr , ' > , ' jmp0 , , ' r> , ' drop , ' r> , ' drop , ; immediate
+: loop+ ' r> , ' + , ' dup , ' >r , ' lit , 1 , ' pickr , ' >= , ' jmp0 , , ' r> , ' drop , ' r> , ' drop , ; immediate
 : loop ' lit , 1 , postpone loop+ ;  immediate
 
 


### PR DESCRIPTION
A couple examples (from Starting Forth [1]):

: decade  10 0 do  i .  loop ;
: sample  -243 -250 do  i .  loop ;
: multiplications  11 1 do  dup i * .  loop  drop ;
: pentajumps  50 0 do  i .  5 loop+ ;

As is, zForth will execute the loop one extra time compared to other implementations I checked (gForth, pForth, jonesforth). The proposed change makes zForth match what others do.

[1] https://www.forth.com/starting-forth/6-forth-do-loops/