### PR TITLE
Improve error reporting to the user on zf_abort()

### DIFF
--- a/src/zforth/zforth.h
+++ b/src/zforth/zforth.h
@@ -63,7 +63,8 @@ void zf_init(int trace);
 void zf_bootstrap(void);
 void *zf_dump(size_t *len);
 zf_result zf_eval(const char *buf);
-void zf_abort(zf_result reason);
+void zf_abort(zf_result reason, const char* abort_buf);
+const char* zf_abort_get_buf();
 
 void zf_push(zf_cell v);
 zf_cell zf_pop(void);


### PR DESCRIPTION
Specifically, allow the caller of zf_abort to specify a pointer to a C-string which will be printed as part of the error message. This allows reporting of the specific token or part of input that caused an abort.

As a bonus, a word lookup error during the processing of PRIM_TICK is reported as "not a word" rather than "internal error".

As another bonus, ZF_ABORT_INVALID_USERVAR is added to the case in main.c where it was missing.

Examples of improved error output:

1 nosuch !
stdin:1: not a word: nosuch

' nopee see
stdin:2: not a word: nopee