### PR TITLE
more precise error in tick'ing an invalid word

### DIFF
--- a/src/zforth/zforth.c
+++ b/src/zforth/zforth.c
@@ -709,7 +709,7 @@ static void do_prim(zf_ctx *ctx, zf_prim op, const char *input)
 			else {
 				if (input) {
 					if (find_word(ctx, input,&addr,&code)) zf_push(ctx, code);
-					else zf_abort(ctx, ZF_ABORT_INTERNAL_ERROR);
+					else zf_abort(ctx, ZF_ABORT_NOT_A_WORD);
 				}
 				else ctx->input_state = ZF_INPUT_PASS_WORD;
 			}


### PR DESCRIPTION
As in the Forth program, `' 1`, the error we want to yield here is, "word not found" and not the more misleading, "internal error."